### PR TITLE
add support of debug v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,13 +43,15 @@ function parse(data) {
   var spl = data.trim().split(' ');
   if (!(spl.length >= 7)) return;
 
-  var date = spl.splice(0, 6).join(' ');
-  if (!utcRegex().test(date)) return;
-
+  var time = spl.shift();
+  var level = 'debug';
+  var name = spl.shift();
+  var message = spl.join(' ');
+  
   return {
-    time: new Date(date).toISOString(),
-    level: 'debug',
-    name: spl.shift(),
-    message: spl.join(' ')
+    time: time,
+    level: level,
+    name: name,
+    message: message,
   };
 }

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ var dtj = require('./');
 describe('debug to json', function() {
   it('should parse `debug` output', function(next) {
     var stream = dtj();
-    var str = 'Sun, 07 Dec 2014 09:44:50 GMT mocha:runner run suite ctx.type= with a mime';
+    var str = '2014-12-07T09:44:50.000Z mocha:runner run suite ctx.type= with a mime';
 
     stream.once('data', function(nw) {
       assert.deepEqual(nw, {


### PR DESCRIPTION
Thank you for good library, and nice `unix-way` solution :).

In `debug` [v3](https://github.com/visionmedia/debug/blob/master/CHANGELOG.md#300--2017-08-08)  was breaking change:

>  Breaking: Use Date#toISOString() instead to Date#toUTCString() when output is not a TTY (#418).

When there is no `tty` or `DEBUG_COLORS=false` date is shown in format `2018-04-15T17:22:37.421Z `.

Current implementation shows nothing:
```
 echo "2018-04-15T17:22:37.421Z mocha:runner run suite ctx.type= with a mime"|dtj
```

I fixed it to work with latest `debug`:
```
$ echo "2018-04-15T17:22:37.421Z mocha:runner run suite ctx.type= with a mime"|dtj
{"time":"2018-04-15T17:22:37.421Z","level":"debug","name":"mocha:runner","message":"run suite ctx.type= with a mime"}
```
